### PR TITLE
Fix ping location when pinging from different zone and using global coordinates

### DIFF
--- a/LoreBooks.lua
+++ b/LoreBooks.lua
@@ -1516,6 +1516,9 @@ local function OnRowMouseUp(control, button)
               function()
                 SetMapToMapId(mapId)
                 GPS:SetPlayerChoseCurrentMap()
+                if libgpsCoordinates then
+                  xLoc, yLoc = GPS:GlobalToLocal(data.px, data.py) -- recalculate on correct map
+                end
                 CALLBACK_MANAGER:FireCallbacks("OnWorldMapChanged")
                 PingMap(MAP_PIN_TYPE_RALLY_POINT, MAP_TYPE_LOCATION_CENTERED, xLoc, yLoc)
                 PingMap(MAP_PIN_TYPE_PLAYER_WAYPOINT, MAP_TYPE_LOCATION_CENTERED, xLoc, yLoc)

--- a/LoreBooks.lua
+++ b/LoreBooks.lua
@@ -1505,6 +1505,10 @@ local function OnRowMouseUp(control, button)
             local xLoc, yLoc
             if libgpsCoordinates then
               xLoc, yLoc = GPS:GlobalToLocal(data.px, data.py)
+              local measurement = GPS:GetMapMeasurementByMapId(mapId)
+              if measurement then 
+                xLoc, yLoc = measurement:ToLocal(data.px, data.py)
+              end 
             end
             if normalizedCoordinates then
               xLoc = data.pnx
@@ -1516,9 +1520,6 @@ local function OnRowMouseUp(control, button)
               function()
                 SetMapToMapId(mapId)
                 GPS:SetPlayerChoseCurrentMap()
-                if libgpsCoordinates then
-                  xLoc, yLoc = GPS:GlobalToLocal(data.px, data.py) -- recalculate on correct map
-                end
                 CALLBACK_MANAGER:FireCallbacks("OnWorldMapChanged")
                 PingMap(MAP_PIN_TYPE_RALLY_POINT, MAP_TYPE_LOCATION_CENTERED, xLoc, yLoc)
                 PingMap(MAP_PIN_TYPE_PLAYER_WAYPOINT, MAP_TYPE_LOCATION_CENTERED, xLoc, yLoc)

--- a/LoreBooks.lua
+++ b/LoreBooks.lua
@@ -1504,7 +1504,6 @@ local function OnRowMouseUp(control, button)
 
             local xLoc, yLoc
             if libgpsCoordinates then
-              xLoc, yLoc = GPS:GlobalToLocal(data.px, data.py)
               local measurement = GPS:GetMapMeasurementByMapId(mapId)
               if measurement then 
                 xLoc, yLoc = measurement:ToLocal(data.px, data.py)

--- a/LoreBooks.txt
+++ b/LoreBooks.txt
@@ -5,7 +5,7 @@
 ## Author: Kyoma, Ayantir, Garkin, Sharlikran
 ## APIVersion: 101035 101036
 ## SavedVariables: LBooks_SavedVariables
-## DependsOn: LibAddonMenu-2.0>=33 LibMapPins-1.0>=10036 CustomCompassPins>=32 LibGPS>=66 LibCustomMenu>=713
+## DependsOn: LibAddonMenu-2.0>=33 LibMapPins-1.0>=10036 CustomCompassPins>=32 LibGPS>=68 LibCustomMenu>=713
 ## DependsOn: LibLoreLibrary>=1 LibMapData>=103
 ## OptionalDependsOn: LibDebugLogger>=220 DebugLogViewer>=558
 


### PR DESCRIPTION
Coordinates are converted from Global to Local on current map, causing wrong ping locations if it's not the same map.
This fixes the pings by calculating local coordinates after changing the map.
The menu option will still display some random coordinates when on different map, but it's not that important