### PR TITLE
Zoning issue fix

### DIFF
--- a/LoreBooks.lua
+++ b/LoreBooks.lua
@@ -414,7 +414,7 @@ local function ShouldDisplayLoreBooks()
 end
 
 local lastZone = ""
-local lastMapIp = 0
+local lastMapId = 0
 local lorebooks
 local bookshelves
 local eideticBooks
@@ -498,7 +498,7 @@ local function MapCallbackCreateShalidorPins(pinType)
 
   local mapId = LMD.mapId
   local zoneMapId = LMD:GetZoneMapIdFromZoneId(LMD.zoneId)
-  if LMD.mapTexture ~= lastZone or lastMapIp ~= mapId then
+  if LMD.mapTexture ~= lastZone or lastMapId ~= mapId then
     UpdateLorebooksData(mapId, zoneMapId)
   end
   local shouldDisplay = ShouldDisplayLoreBooks()
@@ -534,7 +534,7 @@ local function MapCallbackCreateBookshelfPins(pinType)
 
   local mapId = LMD.mapId
   local zoneMapId = LMD:GetZoneMapIdFromZoneId(LMD.zoneId)
-  if LMD.mapTexture ~= lastZone or lastMapIp ~= mapId then
+  if LMD.mapTexture ~= lastZone or lastMapId ~= mapId then
     UpdateLorebooksData(mapId, zoneMapId)
   end
 
@@ -562,7 +562,7 @@ local function MapCallbackCreateEideticPins(pinType)
 
   local mapId = LMD.mapId
   local zoneMapId = LMD:GetZoneMapIdFromZoneId(LMD.zoneId)
-  if LMD.mapTexture ~= lastZone or lastMapIp ~= mapId then
+  if LMD.mapTexture ~= lastZone or lastMapId ~= mapId then
     UpdateLorebooksData(mapId, zoneMapId)
   end
   local isDungeon = LMD.isDungeon

--- a/LoreBooks.lua
+++ b/LoreBooks.lua
@@ -414,6 +414,7 @@ local function ShouldDisplayLoreBooks()
 end
 
 local lastZone = ""
+local lastMapIp = 0
 local lorebooks
 local bookshelves
 local eideticBooks
@@ -423,6 +424,7 @@ local function UpdateLorebooksData(mapId, zoneMapId)
   bookshelves = LoreBooks_GetBookshelfDataFromMapId(mapId)
   eideticBooks = LoreBooks_GetNewEideticDataForMapUniqueId(mapId, zoneMapId)
   lastZone = LMD.mapTexture
+  lastMapId = mapId
 end
 
 local function ShalidorCompassCallback()
@@ -496,7 +498,7 @@ local function MapCallbackCreateShalidorPins(pinType)
 
   local mapId = LMD.mapId
   local zoneMapId = LMD:GetZoneMapIdFromZoneId(LMD.zoneId)
-  if LMD.mapTexture ~= lastZone then
+  if LMD.mapTexture ~= lastZone or lastMapIp ~= mapId then
     UpdateLorebooksData(mapId, zoneMapId)
   end
   local shouldDisplay = ShouldDisplayLoreBooks()
@@ -532,7 +534,7 @@ local function MapCallbackCreateBookshelfPins(pinType)
 
   local mapId = LMD.mapId
   local zoneMapId = LMD:GetZoneMapIdFromZoneId(LMD.zoneId)
-  if LMD.mapTexture ~= lastZone then
+  if LMD.mapTexture ~= lastZone or lastMapIp ~= mapId then
     UpdateLorebooksData(mapId, zoneMapId)
   end
 
@@ -560,7 +562,7 @@ local function MapCallbackCreateEideticPins(pinType)
 
   local mapId = LMD.mapId
   local zoneMapId = LMD:GetZoneMapIdFromZoneId(LMD.zoneId)
-  if LMD.mapTexture ~= lastZone then
+  if LMD.mapTexture ~= lastZone or lastMapIp ~= mapId then
     UpdateLorebooksData(mapId, zoneMapId)
   end
   local isDungeon = LMD.isDungeon


### PR DESCRIPTION
Some zones have multiple sections with different mapIds, but same map texture.
The list of eidetic books for current mapId is only updated if zone texture changed, so pins from previous area are displayed (usually there are none) until map is changed (can be done manually by zooming out).
This fixes it by getting eidetic data for current mapId when it is different then previous.

The areas where I encountered this issue: Zenithar's Abbey in Blackwood, Garrick's Rest in High Isle, Greymoor Keep: West Wing in Blackreach: Greymoor Caverns