### PR TITLE
Fix for new Hireling Correspondence section missing.

### DIFF
--- a/LoreBooks.lua
+++ b/LoreBooks.lua
@@ -233,7 +233,7 @@ pinTooltipCreatorEidetic.creator = function(pin)
   local pinTag = pin.m_PinTag
   local title, icon, known = GetLoreBookInfo(internal.LORE_LIBRARY_EIDETIC, pinTag.c, pinTag.b)
   local collection = GetLoreCollectionInfo(internal.LORE_LIBRARY_EIDETIC, pinTag.c)
-  if icon == MISSING_TEXTURE then icon = PLACEHOLDER_TEXTURE end
+  if icon == internal.MISSING_TEXTURE then icon = internal.PLACEHOLDER_TEXTURE end
   local dungeonMapId = pinTag.pm
   local mapName = zo_strformat(SI_WINDOW_TITLE_WORLD_MAP, GetMapNameById(dungeonMapId))
 

--- a/LoreBooks.lua
+++ b/LoreBooks.lua
@@ -1376,7 +1376,7 @@ local function BuildCategoryList(self)
   end
 
   table.sort(lbcategories, NameSorter)
-
+  local firstNode = nil
   local collectionNodeToSelect = nil
   for i, categoryData in ipairs(lbcategories) do
     local parent = self.navigationTree:AddNode("ZO_LabelHeader", categoryData)
@@ -1408,7 +1408,7 @@ local function BuildCategoryList(self)
     table.sort(lbcategories[i].lbcollections, NameSorter)
 
     local search = string.lower(LORE_LIBRARY.search)
-    local firstNode = nil
+
     for _, collectionData in ipairs(lbcategories[i].lbcollections) do
       local node = self.navigationTree:AddNode("ZO_LoreLibraryNavigationEntry", collectionData, parent)
       if not firstNode then firstNode = node end


### PR DESCRIPTION
feat: Add hireling correspondence sections to Lore Library

- Added function `GetHirelingMessageCollection` to retrieve hireling message collection data.
- Added function `GetHirelingMessages` to retrieve messages for a specific hireling type.
- Modified `RebuildLoreLibrary` to include hireling correspondence sections.
- Updated `FilterScrollList` to handle both lore books and hireling correspondence.
- Fixed error handling for `GetHirelingMessageCollection` function.
- Ensured proper display of data in the scroll list with `ZO_ScrollList_Commit(self.list)`.